### PR TITLE
Also show logo on mobile devices

### DIFF
--- a/public/css/themes/default.less
+++ b/public/css/themes/default.less
@@ -45,6 +45,13 @@
   background-image: url('../img/company/logo-white.svg');
 }
 
+/*
+ * Logo on mobile devices
+ */
+#mobile-menu-logo {
+  background-image: url('../img/company/logo-white.svg');
+}
+
 #layout:not(.minimal-layout).sidebar-collapsed #header-logo {
   background-image: url('../img/company/logo-white-compact.svg');
 }


### PR DESCRIPTION
The ACME logo should also be displayed on mobile devices instead of the default Icinga logo.